### PR TITLE
New classes iterators

### DIFF
--- a/items.lua
+++ b/items.lua
@@ -12,6 +12,17 @@
 	:IterateItems(string)
 		iterates all items in the database or the given string, returning id and name
 		
+		
+	:IterateClasses()
+		iterates all classes and the strings containing their subclasses
+		
+	:IterateSubclasses(subclasses)
+		iterates all subclasses and the strings containing their slots in the given "subclasses string" (from :IterateClasses)
+		
+	:IterateSlots(slots)
+		iterates all slots in the given "slots string" (from :IterateSubclasses)
+		
+		
 	:GetItemName(id)
 		returns name, colorHex
 		
@@ -21,12 +32,16 @@
 
 LudwigDB = {}
 
-local Markers, Matchers = {'{', '}', '$', '€', '£'}, {}
+local Markers, Matchers, Iterators = {'{', '}', '$', '€', '£'}, {}, {}
 local ItemMatch = '(%d+);([^;]+)'
 local Caches, Values = {}, {}
 
 for i, marker in ipairs(Markers) do
 	Matchers[i] = marker..'[^'..marker..']+'
+end
+
+for i = 1, 3 do
+	Iterators[i] = '([%a%s]+)' .. '(' .. Matchers[i] .. ';)'
 end
 
 
@@ -137,7 +152,22 @@ function LudwigDB:IterateItems(section)
 end
 
 
---[[ Data API ]]--
+--[[ Categories API ]]--
+
+function LudwigDB:IterateClasses()
+	return gmatch(Ludwig_Data, Iterators[1])
+end
+
+function LudwigDB:IterateSubClasses(subs)
+	return gmatch(subs, Iterators[2])
+end
+
+function LudwigDB:IterateSlots(slots)
+	return gmatch(slots, Iterators[3])
+end
+
+
+--[[ Item API ]]--
 
 function LudwigDB:GetItemName(id)
 	if id then


### PR DESCRIPTION
Added an API for iterating classes, subclasses and slots in the DB.

```
:IterateClasses
:IterateSubclasses
:IterateSlots
```

For example, if you wish to print all the classes, sub,... etc in the chat you would:

```
for class, subClasses in self:IterateClasses() do
    print(class)

    for subClass, slots in self:IterateSubClasses(subClasses) do
        print('  ' .. subClass)

        for slot in self:IterateSlots(slots) do
            print('    ' .. slot)
        end
    end
end
```
